### PR TITLE
Modified to respect the folders and songs letter case

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -149,7 +149,7 @@ class PlaylistImporter{
      */
 
     _convertToUserFriendly(name){
-        name = name.replace(/(%20)+/g, ' ').toLowerCase();
+        name = name.replace(/(%20)+/g, ' ');
         name = name.split(/(.mp3|.mp4|.wav|.ogg)+/g)[0];
         if(this.DEBUG)
             console.log(`Playlist-Importer: Converting playlist name to eliminate spaces and extension: ${name}.`);


### PR DESCRIPTION
Remove the `.toLowerCase()` when importing folders and songs