### PR TITLE
Fix en.json format so labels are shown correctly

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -23,5 +23,5 @@
     "PLI.LogvolumeHint": "On a scale from 0.0 - 1.0",
     "PLI.EnableDuplicate": "Song Duplicate Checker",
     "PLI.EnableDuplicateHint": "Checks during the importation process to see if duplicate songs exist, excluding them if true.",
-    "PLI.CancelOperation": "Cancel",
+    "PLI.CancelOperation": "Cancel"
 }


### PR DESCRIPTION
When updating the module to the latest version I noticed that all labels are shown as keys. There is an extra comma on the `en.json` file that makes the json parser fail and thus Foundry is not able to use the proper label names.

<img width="595" alt="Screen Shot 2020-10-13 at 11 25 16 AM" src="https://user-images.githubusercontent.com/7726013/95873947-c6da5000-0d46-11eb-8020-628fa82db5f5.png">
