### PR TITLE
Add m4a extension to the list of supported ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you're like me, you probably enjoy amassing a large collection of songs to pl
 Please read the following, as it may answer any questions as to unexpected behavior.
 
 NOTE:
-1. Currently only .mp3, .mp4, .ogg, .wav, and .flac files are imported. All other types are excluded. 
+1. Currently only .mp3, .mp4, .ogg, .wav, .m4a and .flac files are imported. All other types are excluded. 
 1. Organization is force upon you! This means, that when you select your base directory in which to import, only folders within the base directory are checked, not the files. In otherwords, you must subdivide your music into folders inside the base directory.
 1. Songs added by playlist-importer will be excluded from being added again by the import function. This means, songs names should be unique! Make sure to avoid duplicate names across folders.
 1. Nested folders will result in unsuccessful importations. This will be addressed in future builds

--- a/src/main.js
+++ b/src/main.js
@@ -126,7 +126,7 @@ class PlaylistImporter {
     }
 
     /**
-     * Validates the audio extension to be of type mp3, wav, ogg, flac or webm.
+     * Validates the audio extension to be of type mp3, wav, ogg, flac, webm or m4a.
      * @private
      * @param {string} fileName
      */
@@ -135,7 +135,7 @@ class PlaylistImporter {
         let ext = fileName.split(".").pop();
         if (this.DEBUG) console.log(`Playlist-Importer: Extension is determined to be (${ext}).`);
 
-        return !!ext.match(/(mp3|wav|ogg|flac|webm)+/g);
+        return !!ext.match(/(mp3|wav|ogg|flac|webm|m4a)+/g);
 
     }
 
@@ -176,7 +176,7 @@ class PlaylistImporter {
         let words = [], small = ['a', 'an', 'at', 'and', 'but', 'by', 'for', 'if', 'nor', 'on', 'of', 'or', 'so', 'the', 'to', 'yet'];
         let regexReplace = new RegExp(game.settings.get("playlist_import", "customRegexDelete"));
         name = decodeURIComponent(name);
-        name = name.split(/(.mp3|.mp4|.wav|.ogg|.flac)+/g)[0]
+        name = name.split(/(.mp3|.mp4|.wav|.ogg|.flac|.m4a)+/g)[0]
             .replace(regexReplace, '')
             .replace(/[_]+/g, ' ');
 


### PR DESCRIPTION
I have a bunch of audio files with the m4a extension that works pretty well in the FoundryVTT. So I want to purpose to add this extension to this module. I don't know should I bump the version, so I just leave it as is.